### PR TITLE
feat: add unary operators (part2)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Built by following [Nora Sandler’s "Write a Compiler"](https://norasandler.com
 ## Implemented Parts
 
 - [x] Part 1: Compile `int main() { return <int>; }`
-- [ ] Part 2: Add unary operators (`-`, `~`, `!`)
+- [x] Part 2: Add unary operators (`-`, `~`, `!`)
 - [ ] Part 3: Add binary operators (`+`, `-`, etc.)
 - [ ] Part 4+: Control flow, variables, types...
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-stages = [1]
+stages = [1, 2]
 BASE = Path("testsuite")
 any_failed = False
 

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -1,11 +1,23 @@
-use crate::ast::{Expr, Function, Program, Stmt};
+use crate::ast::{Expr, Function, Program, Stmt, UnaryOp};
 use std::fmt;
 
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Const(n) => write!(f, "Int<{}>", n),
+            Expr::UnOp(op, expr) => write!(f, "{}{}", op, expr),
         }
+    }
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let op_str = match self {
+            UnaryOp::Neg => "-",
+            UnaryOp::Not => "!",
+            UnaryOp::BitNot => "~",
+        };
+        write!(f, "{}", op_str)
     }
 }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,16 +1,28 @@
-pub enum Expr {
-    Const(i32),
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnaryOp {
+    Neg,    // -
+    Not,    // !
+    BitNot, // ~
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Const(i32),
+    UnOp(UnaryOp, Box<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Stmt {
     Return(Expr),
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub name: String,
     pub body: Stmt,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct Program {
     pub function: Function,
 }

--- a/src/generator/arm64.rs
+++ b/src/generator/arm64.rs
@@ -1,5 +1,32 @@
-use crate::ast::{Expr, Program, Stmt};
-use std::fmt::Error;
+use crate::ast::{Expr, Program, Stmt, UnaryOp};
+use std::fmt;
+use std::fmt::{Error, Write};
+
+pub fn generate_expr(output: &mut dyn Write, expr: &Expr) -> fmt::Result {
+    match expr {
+        Expr::Const(n) => {
+            writeln!(output, "mov\tw0, #{}", n)?;
+        }
+        Expr::UnOp(op, inner) => {
+            generate_expr(output, inner)?; // recursively evaluate into w0
+
+            match op {
+                UnaryOp::Neg => writeln!(output, "neg\tw0, w0")?,
+                UnaryOp::BitNot => writeln!(output, "mvn\tw0, w0")?,
+                UnaryOp::Not => {
+                    // sets condition flags
+                    writeln!(output, "cmp\tw0, #0")?;
+                    // clear w0
+                    writeln!(output, "mov\tw0, #0")?;
+                    // set w0 = 1 if w0 was equal to 0
+                    writeln!(output, "cset\tw0, eq")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub fn generate(program: &Program) -> Result<String, Error> {
     let function = &program.function;
@@ -13,11 +40,10 @@ pub fn generate(program: &Program) -> Result<String, Error> {
 
     match &function.body {
         Stmt::Return(expr) => {
-            match expr {
-                Expr::Const(n) => {
-                    writeln!(output, "mov	w0, #{}", n)?; // return value
-                }
-            }
+            // no extra handling for return
+            // as long as generate_expr ends with w0 containing the correct result,
+            // the ret instruction will return it
+            generate_expr(&mut output, expr)?;
         }
     }
 

--- a/src/lexer/display.rs
+++ b/src/lexer/display.rs
@@ -13,6 +13,9 @@ impl fmt::Display for Token {
             Token::LBrace => write!(f, "Symbol<{{>"),
             Token::RBrace => write!(f, "Symbol<}}>"),
             Token::Semicolon => write!(f, "Symbol<;>"),
+            Token::Minus => write!(f, "Symbol<->"),
+            Token::Tilde => write!(f, "Symbol<~>"),
+            Token::Bang => write!(f, "Symbol<!>"),
         }
     }
 }

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -50,28 +50,23 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
-        match ch {
-            '(' => {
-                tokens.push(Token::LParen);
-                chars.next();
-            }
-            ')' => {
-                tokens.push(Token::RParen);
-                chars.next();
-            }
-            '{' => {
-                tokens.push(Token::LBrace);
-                chars.next();
-            }
-            '}' => {
-                tokens.push(Token::RBrace);
-                chars.next();
-            }
-            ';' => {
-                tokens.push(Token::Semicolon);
-                chars.next();
-            }
-            _ => return Err(format!("Unexpected character: '{}'", ch)),
+        let token = match ch {
+            '(' => Some(Token::LParen),
+            ')' => Some(Token::RParen),
+            '{' => Some(Token::LBrace),
+            '}' => Some(Token::RBrace),
+            ';' => Some(Token::Semicolon),
+            '-' => Some(Token::Minus),
+            '~' => Some(Token::Tilde),
+            '!' => Some(Token::Bang),
+            _ => None,
+        };
+
+        if let Some(tok) = token {
+            tokens.push(tok);
+            chars.next();
+        } else {
+            return Err(format!("Unexpected character: '{}'", ch));
         }
     }
 

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -9,4 +9,7 @@ pub enum Token {
     LBrace,             // {
     RBrace,             // }
     Semicolon,          // ;
+    Minus,              // -
+    Tilde,              // ~
+    Bang,               // !
 }

--- a/tests/nested_ops.c
+++ b/tests/nested_ops.c
@@ -1,0 +1,3 @@
+int main() {
+    return -~7;
+}


### PR DESCRIPTION
Add support for unary operators (`-`, `~`, `!`) in AST, parser, and ARM64 codegen.
Enable `stage 2` in test suite