### PR TITLE
feat: run_tests.py: compile both *.c and *.s files, compare outputs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,4 @@ jobs:
         run: python3 run_tests.py
         env:
           GITHUB_ANNOTATIONS: "1"
+          DISABLE_COMPILE: "1"


### PR DESCRIPTION
Add a compiling feature to `run_tests.py`: if `DISABLE_COMPILE` is not set, the script compiles both the original `*.c` and the generated `*.s` files, then compares their outputs and return codes.

Note: current implementation uses `clang for compiling, it is disabled in ci/cd for now