### PR TITLE
feat: compiler: more binary operators (part 4)

### DIFF
--- a/examples/not_zero.c
+++ b/examples/not_zero.c
@@ -1,0 +1,3 @@
+int main() {
+    return !0;
+}

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Built by following [Nora Sandler’s "Write a Compiler"](https://norasandler.com
 - [x] Part 1: Compile `int main() { return <int>; }`
 - [x] Part 2: Add unary operators (`-`, `~`, `!`)
 - [x] Part 3: Add binary operators (`+`, `-`, etc.)
-- [ ] Part 4: Even More Binary Operators
+- [x] Part 4: Even More Binary Operators (`&&`, `||`, `==`, `!=`, `<`, `<=`, `>`, `>=`)
 - [ ] Part 5: Local Variables
 - [ ] Part 6: Conditionals
 - [ ] Part 7: Compound Statements

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import os
 import difflib
 
-STAGES = [1, 2, 3]
+STAGES = [1, 2, 3, 4]
 TARGET_ARCHS = ['aarch64']
 BASE = Path("testsuite")
 
@@ -120,7 +120,12 @@ def run_test(c_file: Path, expect_success: bool, arch: str) -> bool:
     )
     success = result.returncode == 0
     if expect_success and not success:
+        if c_file.name.startswith("skip_on_failure"):
+            print(f"{YELLOW}SKIPPED (skip_on_failure){RESET}")
+            return True
+
         print(f"{RED}ERROR: should succeed{RESET}")
+        print(f"{result.stdout.decode()}")
         print(f"{result.stderr.decode()}")
         return False
     elif not expect_success and success:

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -29,6 +29,17 @@ impl fmt::Display for BinaryOp {
             BinaryOp::Sub => "-",
             BinaryOp::Add => "+",
             BinaryOp::Divide => "/",
+
+            BinaryOp::Greater => ">",
+            BinaryOp::GreaterEqual => ">=",
+            BinaryOp::Less => "<",
+            BinaryOp::LessEqual => "<=",
+
+            BinaryOp::Equal => "==",
+            BinaryOp::NotEqual => "!=",
+
+            BinaryOp::LogicalAnd => "&&",
+            BinaryOp::LogicalOr => "||",
         };
         write!(f, "{}", op_str)
     }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -11,6 +11,18 @@ pub enum BinaryOp {
     Sub,
     Multiply,
     Divide,
+
+    Greater,
+    Less,
+
+    GreaterEqual,
+    LessEqual,
+
+    Equal,
+    NotEqual,
+
+    LogicalAnd,
+    LogicalOr,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/generator/arm64.rs
+++ b/src/generator/arm64.rs
@@ -1,15 +1,20 @@
 use crate::ast::Expr::BinOp;
 use crate::ast::{BinaryOp, Expr, Program, Stmt, UnaryOp};
+use crate::generator::label::LabelGenerator;
 use std::fmt;
 use std::fmt::Write;
 
-pub fn generate_expr(output: &mut dyn Write, expr: &Expr) -> fmt::Result {
+pub fn generate_expr(
+    output: &mut dyn Write,
+    expr: &Expr,
+    labels: &mut LabelGenerator,
+) -> fmt::Result {
     match expr {
         Expr::Const(n) => {
             writeln!(output, "mov\tw0, #{}", n)?;
         }
         Expr::UnOp(op, inner) => {
-            generate_expr(output, inner)?; // recursively evaluate into w0
+            generate_expr(output, inner, labels)?; // recursively evaluate into w0
 
             match op {
                 UnaryOp::Neg => writeln!(output, "neg\tw0, w0")?,
@@ -24,11 +29,47 @@ pub fn generate_expr(output: &mut dyn Write, expr: &Expr) -> fmt::Result {
                 }
             }
         }
+        BinOp(BinaryOp::LogicalOr, lhs, rhs) => {
+            let true_clause = labels.next("or_true");
+            let end_clause = labels.next("or_end");
+
+            generate_expr(output, lhs, labels)?; // result in w0
+
+            writeln!(output, "cmp\tw0, #0")?; // check if lhs is true (non-zero)
+            writeln!(output, "b.ne\t{}", true_clause)?; // if lhs != 0, short-circuit: result is true
+
+            generate_expr(output, rhs, labels)?; // result in w0
+            writeln!(output, "cmp\tw0, #0")?; // check if rhs is true (non-zero)
+            writeln!(output, "cset\tw0, ne")?; // w0 = 1 if rhs != 0, else 0
+            writeln!(output, "b\t{}", end_clause)?;
+
+            writeln!(output, "{}:", true_clause)?;
+            writeln!(output, "mov\tw0, #1")?; // result is 1
+            writeln!(output, "{}:", end_clause)?;
+        }
+        BinOp(BinaryOp::LogicalAnd, lhs, rhs) => {
+            let false_clause = labels.next("and_false");
+            let end_clause = labels.next("and_end");
+
+            generate_expr(output, lhs, labels)?; // result in w0
+
+            writeln!(output, "cmp\tw0, #0")?; // check if lhs is false (zero)
+            writeln!(output, "b.eq\t{}", false_clause)?; // if lhs == 0, short-circuit: result is false
+
+            generate_expr(output, rhs, labels)?; // result in w0
+            writeln!(output, "cmp\tw0, #0")?; // check if rhs is true (non-zero)
+            writeln!(output, "cset\tw0, ne")?; // w0 = 1 if rhs != 0, else 0
+            writeln!(output, "b\t{}", end_clause)?;
+
+            writeln!(output, "{}:", false_clause)?;
+            writeln!(output, "mov\tw0, #0")?; // result is 0
+            writeln!(output, "{}:", end_clause)?;
+        }
         BinOp(op, lhs, rhs) => {
-            generate_expr(output, lhs)?;
+            generate_expr(output, lhs, labels)?;
             writeln!(output, "str\tw0, [sp, #-16]!")?; // push w0 on stack
 
-            generate_expr(output, rhs)?;
+            generate_expr(output, rhs, labels)?;
             writeln!(output, "ldr\tw1, [sp], #16")?; // pop previous w0 result into w1
 
             // w0 - result of evaluating rhs
@@ -39,6 +80,33 @@ pub fn generate_expr(output: &mut dyn Write, expr: &Expr) -> fmt::Result {
                 BinaryOp::Sub => writeln!(output, "sub\tw0, w1, w0")?,
                 BinaryOp::Multiply => writeln!(output, "mul\tw0, w1, w0")?,
                 BinaryOp::Divide => writeln!(output, "sdiv\tw0, w1, w0")?,
+
+                BinaryOp::Equal => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, eq")?;
+                }
+                BinaryOp::NotEqual => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, ne")?;
+                }
+                BinaryOp::Less => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, lt")?;
+                }
+                BinaryOp::LessEqual => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, le")?;
+                }
+                BinaryOp::Greater => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, gt")?;
+                }
+                BinaryOp::GreaterEqual => {
+                    writeln!(output, "cmp\tw1, w0")?;
+                    writeln!(output, "cset\tw0, ge")?;
+                }
+
+                op => panic!("op {op} is not supported"),
             }
         }
     }
@@ -60,12 +128,14 @@ pub fn generate(program: &Program, platform: &str) -> Result<String, Box<dyn std
     writeln!(output, "{}main:", prefix)?;
     writeln!(output, "sub	sp, sp, #16")?; // reserve stack space
 
+    let mut labels = LabelGenerator::new();
+
     match &function.body {
         Stmt::Return(expr) => {
             // no extra handling for return
             // as long as generate_expr ends with w0 containing the correct result,
             // the ret instruction will return it
-            generate_expr(&mut output, expr)?;
+            generate_expr(&mut output, expr, &mut labels)?;
         }
     }
 

--- a/src/generator/label.rs
+++ b/src/generator/label.rs
@@ -1,0 +1,13 @@
+pub struct LabelGenerator {
+    pos: usize,
+}
+
+impl LabelGenerator {
+    pub fn new() -> Self {
+        Self { pos: 0 }
+    }
+    pub fn next(&mut self, prefix: &str) -> String {
+        self.pos += 1;
+        format!("{}_{}", prefix, self.pos)
+    }
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,1 +1,2 @@
 pub mod arm64;
+mod label;

--- a/src/lexer/display.rs
+++ b/src/lexer/display.rs
@@ -6,19 +6,33 @@ impl fmt::Display for Token {
         match self {
             Token::KeywordInt => write!(f, "Keyword<int>"),
             Token::KeywordReturn => write!(f, "Keyword<return>"),
+
             Token::Identifier(name) => write!(f, "Identifier<{}>", name),
             Token::IntLiteral(n) => write!(f, "IntLiteral<{}>", n),
+
             Token::LParen => write!(f, "Symbol<(>"),
             Token::RParen => write!(f, "Symbol<)>"),
             Token::LBrace => write!(f, "Symbol<{{>"),
             Token::RBrace => write!(f, "Symbol<}}>"),
             Token::Semicolon => write!(f, "Symbol<;>"),
+
             Token::Minus => write!(f, "Symbol<->"),
             Token::Tilde => write!(f, "Symbol<~>"),
             Token::Bang => write!(f, "Symbol<!>"),
+
             Token::Plus => write!(f, "Symbol<+>"),
             Token::Asterisk => write!(f, "Symbol<*>"),
             Token::Slash => write!(f, "Symbol</>"),
+
+            Token::AndAnd => write!(f, "Symbol<&&>"),
+            Token::OrOr => write!(f, "Symbol<||>"),
+
+            Token::EqualEqual => write!(f, "Symbol< == >"),
+            Token::BangEqual => write!(f, "Symbol< != >"),
+            Token::Less => write!(f, "Symbol< < >"),
+            Token::LessEqual => write!(f, "Symbol< <= >"),
+            Token::Greater => write!(f, "Symbol< > >"),
+            Token::GreaterEqual => write!(f, "Symbol< >= >"),
         }
     }
 }

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -50,26 +50,109 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
-        let token = match ch {
-            '(' => Some(Token::LParen),
-            ')' => Some(Token::RParen),
-            '{' => Some(Token::LBrace),
-            '}' => Some(Token::RBrace),
-            ';' => Some(Token::Semicolon),
-            '-' => Some(Token::Minus),
-            '~' => Some(Token::Tilde),
-            '!' => Some(Token::Bang),
-            '+' => Some(Token::Plus),
-            '*' => Some(Token::Asterisk),
-            '/' => Some(Token::Slash),
-            _ => None,
-        };
+        match ch {
+            '(' => {
+                chars.next();
+                tokens.push(Token::LParen);
+            }
+            ')' => {
+                chars.next();
+                tokens.push(Token::RParen);
+            }
+            '{' => {
+                chars.next();
+                tokens.push(Token::LBrace);
+            }
+            '}' => {
+                chars.next();
+                tokens.push(Token::RBrace);
+            }
+            ';' => {
+                chars.next();
+                tokens.push(Token::Semicolon);
+            }
+            '-' => {
+                chars.next();
+                tokens.push(Token::Minus);
+            }
+            '~' => {
+                chars.next();
+                tokens.push(Token::Tilde);
+            }
+            '+' => {
+                chars.next();
+                tokens.push(Token::Plus);
+            }
+            '*' => {
+                chars.next();
+                tokens.push(Token::Asterisk);
+            }
+            '/' => {
+                chars.next();
+                tokens.push(Token::Slash);
+            }
 
-        if let Some(tok) = token {
-            tokens.push(tok);
-            chars.next();
-        } else {
-            return Err(format!("Unexpected character: '{}'", ch));
+            '>' => {
+                chars.next();
+                if chars.peek() == Some(&'=') {
+                    chars.next();
+                    tokens.push(Token::GreaterEqual);
+                } else {
+                    tokens.push(Token::Greater);
+                }
+            }
+
+            '<' => {
+                chars.next();
+                if chars.peek() == Some(&'=') {
+                    chars.next();
+                    tokens.push(Token::LessEqual);
+                } else {
+                    tokens.push(Token::Less);
+                }
+            }
+
+            '!' => {
+                chars.next();
+                if chars.peek() == Some(&'=') {
+                    chars.next();
+                    tokens.push(Token::BangEqual);
+                } else {
+                    tokens.push(Token::Bang);
+                }
+            }
+
+            '=' => {
+                chars.next();
+                if chars.peek() == Some(&'=') {
+                    chars.next();
+                    tokens.push(Token::EqualEqual);
+                } else {
+                    return Err("Unexpected character: '='".to_string());
+                }
+            }
+
+            '&' => {
+                chars.next();
+                if chars.peek() == Some(&'&') {
+                    chars.next();
+                    tokens.push(Token::AndAnd);
+                } else {
+                    return Err("Unexpected character: '&'".to_string());
+                }
+            }
+
+            '|' => {
+                chars.next();
+                if chars.peek() == Some(&'|') {
+                    chars.next();
+                    tokens.push(Token::OrOr);
+                } else {
+                    return Err("Unexpected character: '|'".to_string());
+                }
+            }
+
+            _ => return Err(format!("Unexpected character: '{}'", ch)),
         }
     }
 

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -1,18 +1,39 @@
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
-    KeywordInt,         // "int"
-    KeywordReturn,      // "return"
+    // Keywords
+    KeywordInt,    // "int"
+    KeywordReturn, // "return"
+
+    // Identifiers and literals
     Identifier(String), // e.g. "main"
     IntLiteral(i32),    // e.g. 123
-    LParen,             // (
-    RParen,             // )
-    LBrace,             // {
-    RBrace,             // }
-    Semicolon,          // ;
-    Minus,              // -
-    Tilde,              // ~
-    Bang,               // !
-    Plus,               // +
-    Asterisk,           // *
-    Slash,              // /
+
+    // Punctuation
+    LParen,    // (
+    RParen,    // )
+    LBrace,    // {
+    RBrace,    // }
+    Semicolon, // ;
+
+    // Unary operators
+    Minus, // -
+    Tilde, // ~
+    Bang,  // !
+
+    // Binary arithmetic operators
+    Plus,     // +
+    Asterisk, // *
+    Slash,    // /
+
+    // Logical operators
+    AndAnd, // &&
+    OrOr,   // ||
+
+    // Comparison operators
+    EqualEqual,   // ==
+    BangEqual,    // !=
+    Less,         // <
+    LessEqual,    // <=
+    Greater,      // >
+    GreaterEqual, // >=
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let input = std::fs::read_to_string(&input_path)?;
     let tokens = lex(&input).expect("Lexer failed");
+    println!("{:?}", tokens);
+
     let program = parse(&tokens).expect("Parser failed");
 
     println!("{}", program);

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,0 +1,126 @@
+use crate::ast::Expr::BinOp;
+use crate::ast::{BinaryOp, Expr, UnaryOp};
+use crate::lexer::Token;
+
+// From highest to lowest (tighter binding first):
+// parse_factor – literals, parentheses, unary operators
+// parse_term – *, /
+// parse_additive_exp – +, -
+// parse_relational_exp – <, >, <=, >=
+// parse_equality_exp – ==, !=
+// parse_logical_and_exp – &&
+// parse_expr – || (top-level)
+
+// helper
+fn parse_binary_chain(
+    tokens: &[Token],
+    pos: &mut usize,
+    parse_operand: fn(&[Token], &mut usize) -> Result<Expr, String>,
+    match_op: fn(&Token) -> Option<BinaryOp>,
+) -> Result<Expr, String> {
+    let mut left = parse_operand(tokens, pos)?;
+
+    while let Some(token) = tokens.get(*pos) {
+        if let Some(op) = match_op(token) {
+            *pos += 1;
+            let right = parse_operand(tokens, pos)?;
+            left = BinOp(op, Box::new(left), Box::new(right));
+        } else {
+            break;
+        }
+    }
+
+    Ok(left)
+}
+
+fn parse_factor(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    match tokens.get(*pos) {
+        Some(Token::IntLiteral(n)) => {
+            *pos += 1;
+            Ok(Expr::Const(*n))
+        }
+
+        Some(Token::LParen) => {
+            *pos += 1;
+            let expr = parse_expr(tokens, pos)?;
+            if tokens.get(*pos) == Some(&Token::RParen) {
+                *pos += 1;
+                Ok(expr)
+            } else {
+                Err("expected ')'".to_string())
+            }
+        }
+
+        Some(Token::Minus | Token::Tilde | Token::Bang) => {
+            let op = match tokens[*pos] {
+                Token::Minus => UnaryOp::Neg,
+                Token::Tilde => UnaryOp::BitNot,
+                Token::Bang => UnaryOp::Not,
+                _ => unreachable!(),
+            };
+            *pos += 1;
+            let inner = parse_factor(tokens, pos)?;
+            Ok(Expr::UnOp(op, Box::new(inner)))
+        }
+
+        other => Err(format!("expected factor, found {:?}", other)),
+    }
+}
+
+fn parse_term(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    let mut expr = parse_factor(tokens, pos)?;
+
+    while let Some(op_token) = tokens.get(*pos) {
+        let op = match op_token {
+            Token::Asterisk => BinaryOp::Multiply,
+            Token::Slash => BinaryOp::Divide,
+            _ => break, // not a term-level operator, stop looping
+        };
+
+        *pos += 1;
+        let rhs = parse_factor(tokens, pos)?;
+        expr = BinOp(op, Box::new(expr), Box::new(rhs));
+    }
+
+    Ok(expr)
+}
+
+fn parse_additive_exp(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    parse_binary_chain(tokens, pos, parse_term, |tok| match tok {
+        Token::Plus => Some(BinaryOp::Add),
+        Token::Minus => Some(BinaryOp::Sub),
+        _ => None,
+    })
+}
+
+fn parse_relational_exp(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    parse_binary_chain(tokens, pos, parse_additive_exp, |tok| match tok {
+        Token::Less => Some(BinaryOp::Less),
+        Token::LessEqual => Some(BinaryOp::LessEqual),
+        Token::Greater => Some(BinaryOp::Greater),
+        Token::GreaterEqual => Some(BinaryOp::GreaterEqual),
+        _ => None,
+    })
+}
+
+fn parse_equality_exp(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    parse_binary_chain(tokens, pos, parse_relational_exp, |tok| match tok {
+        Token::EqualEqual => Some(BinaryOp::Equal),
+        Token::BangEqual => Some(BinaryOp::NotEqual),
+        _ => None,
+    })
+}
+
+fn parse_logical_and_exp(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    parse_binary_chain(tokens, pos, parse_equality_exp, |tok| match tok {
+        Token::AndAnd => Some(BinaryOp::LogicalAnd),
+        _ => None,
+    })
+}
+
+pub fn parse_expr(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
+    parse_binary_chain(tokens, pos, parse_logical_and_exp, |tok| match tok {
+        Token::OrOr => Some(BinaryOp::LogicalOr),
+        _ => None,
+    })
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,4 @@
+mod expr;
 pub mod parse;
 
 pub use parse::parse;

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1,6 +1,6 @@
-use crate::ast::Expr::BinOp;
-use crate::ast::{BinaryOp, Expr, Function, Program, Stmt, UnaryOp};
+use crate::ast::{Function, Program, Stmt};
 use crate::lexer::Token;
+use crate::parser::expr::parse_expr;
 
 fn expect(tokens: &[Token], pos: &mut usize, expected: &Token) -> Result<(), String> {
     if tokens.get(*pos) == Some(expected) {
@@ -26,76 +26,6 @@ fn expect_ident(tokens: &[Token], pos: &mut usize) -> Result<String, String> {
         }
         other => Err(format!("expected identifier, found {:?}", other)),
     }
-}
-
-fn parse_term(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
-    let mut expr = parse_factor(tokens, pos)?;
-
-    while let Some(op_token) = tokens.get(*pos) {
-        let op = match op_token {
-            Token::Asterisk => BinaryOp::Multiply,
-            Token::Slash => BinaryOp::Divide,
-            _ => break, // not a term-level operator, stop looping
-        };
-
-        *pos += 1;
-        let rhs = parse_factor(tokens, pos)?;
-        expr = BinOp(op, Box::new(expr), Box::new(rhs));
-    }
-
-    Ok(expr)
-}
-
-fn parse_factor(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
-    match tokens.get(*pos) {
-        Some(Token::IntLiteral(n)) => {
-            *pos += 1;
-            Ok(Expr::Const(*n))
-        }
-
-        Some(Token::LParen) => {
-            *pos += 1;
-            let expr = parse_expr(tokens, pos)?;
-            if tokens.get(*pos) == Some(&Token::RParen) {
-                *pos += 1;
-                Ok(expr)
-            } else {
-                Err("expected ')'".to_string())
-            }
-        }
-
-        Some(Token::Minus | Token::Tilde | Token::Bang) => {
-            let op = match tokens[*pos] {
-                Token::Minus => UnaryOp::Neg,
-                Token::Tilde => UnaryOp::BitNot,
-                Token::Bang => UnaryOp::Not,
-                _ => unreachable!(),
-            };
-            *pos += 1;
-            let inner = parse_factor(tokens, pos)?;
-            Ok(Expr::UnOp(op, Box::new(inner)))
-        }
-
-        other => Err(format!("expected factor, found {:?}", other)),
-    }
-}
-
-fn parse_expr(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
-    let mut left = parse_term(tokens, pos)?;
-
-    while let Some(op_token) = tokens.get(*pos) {
-        let op = match op_token {
-            Token::Plus => BinaryOp::Add,
-            Token::Minus => BinaryOp::Sub,
-            _ => break, // stop loop if it's not a + or -
-        };
-
-        *pos += 1;
-        let right = parse_term(tokens, pos)?;
-        left = BinOp(op, Box::new(left), Box::new(right));
-    }
-
-    Ok(left)
 }
 
 pub fn parse(tokens: &[Token]) -> Result<Program, String> {
@@ -126,6 +56,7 @@ pub fn parse(tokens: &[Token]) -> Result<Program, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::Expr;
     use crate::lexer::lex;
 
     #[test]


### PR DESCRIPTION
Add support for `&&`, `||`, `==`, `!=`, `<`, `<=`, `>`, `>=` operators, extending the parser with new precedence 
```python
# precedence from highest to lowest
parse_factor – literals, parentheses, unary operators          
parse_term – *, /                                              
parse_additive_exp – +, -                                      
parse_relational_exp – <, >, <=, >=                            
parse_equality_exp – ==, !=                                    
parse_logical_and_exp – &&                                     
parse_expr – || (top-level)
```                                    

- Implement correct short-circuit evaluation for `&&` and `||`, add primitive label generator for it
- (run_tests.py) Skip `skip_on_failure_*` tests since they depend on unimplemented local variables

> These tests are included to check short-circuiting behavior but are expected to return NOT_IMPLEMENTED. They do not count toward total failures and should pass once local variables are supported. [Source](https://norasandler.com/2017/12/28/Write-a-Compiler-4.html)
