### PR TITLE
feat: local variables (part 5)

### DIFF
--- a/examples/return_42.c
+++ b/examples/return_42.c
@@ -1,3 +1,0 @@
-int main() {
-    return 42;
-}

--- a/examples/vars_new.c
+++ b/examples/vars_new.c
@@ -1,0 +1,46 @@
+int main()
+{
+    int a0  =  1;
+    int a1  =  2;
+    int a2  =  3;
+    int a3  =  4;
+    int a4  =  5;
+    int a5  =  6;
+    int a6  =  7;
+    int a7  =  8;
+    int a8  =  9;
+    int a9  = 10;
+    int a10 = 11;
+    int a11 = 12;
+    int a12 = 13;
+    int a13 = 14;
+    int a14 = 15;
+    int a15 = 16;
+    int a16 = 17;
+    int a17 = 18;
+    int a18 = 19;
+    int a19 = 20;
+
+    int t0  = 0;
+    int t1  = 0;
+    int t2  = 0;
+    int result = 0;
+
+    t0 = (a0 + a1) * (a2 - a3);
+    a4 = a4 + a5;
+    a5 = a5 / 2;
+    a6 = (a6 + a7) * (a8 - a9);
+    a10 = (a10 + (a11 * a12)) / (a13 - 1);
+    a14 = (a14 - a15) + (a16 * a17);
+    a18 = (a18 + a19) / 3;
+
+    t1 = (a2 > a3) && (a4 < a5);
+    t2 = (a6 >= a10) || (a14 <= a18);
+
+    result = t0 + t1 + t2;
+
+    result = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9
+            + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + result;
+
+    return result;
+}

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import os
 import difflib
 
-STAGES = [1, 2, 3, 4]
+STAGES = [1, 2, 3, 4, 5]
 TARGET_ARCHS = ['aarch64']
 BASE = Path("testsuite")
 
@@ -89,6 +89,13 @@ def compare_c_and_s_outputs(c_file: Path, s_file: Path, arch: str = "arm64") -> 
     except subprocess.CalledProcessError as e:
         print(f"{RED}Compilation failed: {e}{RESET}")
         return False
+    finally:
+        for bin_file in (bin_c, bin_s):
+            if bin_file.exists():
+                try:
+                    bin_file.unlink()
+                except Exception as e:
+                    print(f"{RED}Failed to delete {bin_file}: {e}{RESET}")
 
     match_output = output_c == output_s
     match_code = code_c == code_s
@@ -146,6 +153,14 @@ def main():
         total = 0
         passed = 0
         failed = 0
+
+        examples_dir =Path("examples")
+        for f in examples_dir.glob("*.c"):
+            total += 1
+            if run_test(f, expect_success=True, arch=arch):
+                passed += 1
+            else:
+                failed += 1
 
         for stage in STAGES:
             stage_dir = BASE / f"stage_{stage}"

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -7,6 +7,8 @@ impl fmt::Display for Expr {
             Expr::Const(n) => write!(f, "Int<{}>", n),
             Expr::UnOp(op, expr) => write!(f, "{}{}", op, expr),
             Expr::BinOp(op, lhs, rhs) => write!(f, "({} {} {})", lhs, op, rhs),
+            Expr::Var(name) => write!(f, "(var {})", name),
+            Expr::Assign(name, exp) => write!(f, "{} = {}", name, exp),
         }
     }
 }
@@ -51,6 +53,15 @@ impl fmt::Display for Stmt {
             Stmt::Return(expr) => {
                 writeln!(f, "return {}", expr)
             }
+            Stmt::Declare(name, Some(expr)) => {
+                writeln!(f, "declare {} = {}", name, expr)
+            }
+            Stmt::Declare(name, None) => {
+                writeln!(f, "declare {}", name)
+            }
+            Stmt::Expr(expr) => {
+                writeln!(f, "{}", expr)
+            }
         }
     }
 }
@@ -59,7 +70,7 @@ impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "function int {}:", self.name)?;
         writeln!(f, "    params: ()")?;
-        writeln!(f, "    body:\n        {}", self.body)
+        writeln!(f, "    body:\n        {:?}", self.body)
     }
 }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -30,17 +30,21 @@ pub enum Expr {
     Const(i32),
     UnOp(UnaryOp, Box<Expr>),
     BinOp(BinaryOp, Box<Expr>, Box<Expr>),
+    Var(String),
+    Assign(String, Box<Expr>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Stmt {
     Return(Expr),
+    Declare(String, Option<Expr>),
+    Expr(Expr),
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub name: String,
-    pub body: Stmt,
+    pub body: Vec<Stmt>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/generator/allocator.rs
+++ b/src/generator/allocator.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Variable {
+    Stack(i32), // offset
+    Register(String),
+}
+
+pub struct Allocator {
+    next_stack_offset: i32,
+    used_registers: Vec<String>,
+    vars: HashMap<String, Variable>,
+}
+
+impl Allocator {
+    pub fn new(registers: Vec<&str>) -> Self {
+        Self {
+            next_stack_offset: 0,
+            used_registers: registers.iter().cloned().map(str::to_string).collect(),
+            vars: HashMap::new(),
+        }
+    }
+
+    pub fn allocate(&mut self, name: String, size: i32) -> Variable {
+        if size == 4 {
+            if let Some(var) = self.try_allocate_register(name.clone()) {
+                return var;
+            }
+        }
+        self.allocate_stack(name, size)
+    }
+
+    fn try_allocate_register(&mut self, name: String) -> Option<Variable> {
+        if self.used_registers.is_empty() {
+            return None;
+        }
+
+        let register = self.used_registers.pop().unwrap();
+        let var = Variable::Register(register);
+
+        self.vars.insert(name, var.clone());
+        Some(var)
+    }
+
+    fn allocate_stack(&mut self, name: String, size: i32) -> Variable {
+        self.next_stack_offset -= size; // alignment
+        let var = Variable::Stack(self.next_stack_offset);
+        self.vars.insert(name, var.clone());
+        var
+    }
+
+    pub fn get(&self, name: &str) -> Option<&Variable> {
+        self.vars.get(name)
+    }
+
+    pub fn total_stack_size(&self) -> i32 {
+        self.next_stack_offset.abs()
+    }
+
+    // Optionally: implement allocate_register if you’re doing register allocation
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,2 +1,3 @@
+mod allocator;
 pub mod arm64;
 mod label;

--- a/src/lexer/display.rs
+++ b/src/lexer/display.rs
@@ -28,6 +28,8 @@ impl fmt::Display for Token {
             Token::OrOr => write!(f, "Symbol<||>"),
 
             Token::EqualEqual => write!(f, "Symbol< == >"),
+            Token::Equal => write!(f, "Symbol<=>"),
+
             Token::BangEqual => write!(f, "Symbol< != >"),
             Token::Less => write!(f, "Symbol< < >"),
             Token::LessEqual => write!(f, "Symbol< <= >"),

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -36,4 +36,6 @@ pub enum Token {
     LessEqual,    // <=
     Greater,      // >
     GreaterEqual, // >=
+
+    Equal,
 }


### PR DESCRIPTION
https://norasandler.com/2018/01/08/Write-a-Compiler-5.html
Adds support for local variables for the `main` func.

Lexer: supports `=` and comments (`//`, `/* */`) 
Parser: new `parse_statement` phase for returns and variables declarations/assignments.
Backend: local-variable allocator uses callee-saved registers (`w19`-`w28`) first, then 16-byte-aligned stack; every function gets a proper prologue/epilogue instructions
Tests: `examples` folder is now included, script removes binary files after outputs matching