### PR TITLE
feat: add bingus keyword to print values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,29 @@ clang -arch arm64 -o return_42_mac return_42.s
 echo $?  # prints: 42
 ```
 
+## Non-standard features
+
+### `bingus` keyword
+`bingus(arg)` is a built-in pseudo-function, which evaluates expression and prints it into stdout. Available on macOS platform
+
+Until functions are supported, it is the only way to print something (e.g. for debug purposes)
+
+Example:
+```c
+int main() {
+    int a = 10, b = 8;
+    bingus(a);
+    bingus(a * b);
+    bingus(b - 10);
+}
+```
+Output:
+```
+10
+80
+-2
+```
+
 ## Tests
 The `testsuite` submodule contains tests cases from [`nlsandler/write_a_c_compiler`](https://github.com/nlsandler/write_a_c_compiler). 
 

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -59,18 +59,11 @@ impl fmt::Display for BinaryOp {
 impl fmt::Display for Stmt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Stmt::Return(expr) => {
-                writeln!(f, "return {}", expr)
-            }
-            Stmt::Declare(name, Some(expr)) => {
-                writeln!(f, "declare {} = {}", name, expr)
-            }
-            Stmt::Declare(name, None) => {
-                writeln!(f, "declare {}", name)
-            }
-            Stmt::Expr(expr) => {
-                writeln!(f, "{}", expr)
-            }
+            Stmt::Return(expr) => writeln!(f, "return {}", expr),
+            Stmt::Declare(name, Some(expr)) => writeln!(f, "declare {} = {}", name, expr),
+            Stmt::Declare(name, None) => writeln!(f, "declare {}", name),
+            Stmt::Expr(expr) => writeln!(f, "{}", expr),
+            Stmt::Bingus(expr) => writeln!(f, "bingus {}", expr),
         }
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -46,6 +46,8 @@ pub enum Stmt {
     Return(Expr),
     Declare(String, Option<Expr>),
     Expr(Expr),
+
+    Bingus(Expr), // print expr int val
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/generator/bingus_arm64_macos.s
+++ b/src/generator/bingus_arm64_macos.s
@@ -1,0 +1,84 @@
+    .text
+    .global bingus
+    .p2align    2
+
+bingus:
+    // — Prologue: save fp & lr, alloc 32-byte frame
+    stp     x29, x30, [sp, #-32]!
+    mov     x29, sp
+
+    // save original w0 for sign test
+    str     w0, [sp, #16]
+
+    // sign-extend w0 → x1
+    sxtw    x1, w0
+
+    // x2 → end-of-buffer on stack
+    mov     x2, sp
+    add     x2, x2, #32
+
+    // init counters & flags
+    mov     w3, 0           // digit count
+    mov     w7, 0           // initialize negative flag
+    // if x1 == 0 → handle “0”
+    cbz     x1, .zero_case
+
+    // if negative, negate & mark flag
+    cmp     x1, #0
+    b.ge    .convert_loop
+    neg     x1, x1
+    mov     w7, 1           // mark negative
+    b       .convert_start
+
+.convert_loop:
+    mov     x4, 10
+    udiv    x5, x1, x4      // q = x1/10
+    msub    x6, x5, x4, x1  // r = x1 – q*10
+    add     w6, w6, #'0'    // ascii digit
+    sub     x2, x2, 1
+    strb    w6, [x2]
+    mov     x1, x5
+    add     w3, w3, 1
+    cbnz    x1, .convert_loop
+    b       .maybe_negative_sign
+
+.convert_start:
+    // (we already set w4 above)
+    b       .convert_loop
+
+.zero_case:
+    sub     x2, x2, 1
+    mov     w6, #'0'
+    strb    w6, [x2]
+    mov     w3, 1
+    mov     w4, 0
+    b       .print_number
+
+.maybe_negative_sign:
+    cmp     w7, 0
+    beq     .print_number
+    sub     x2, x2, 1
+    mov     w6, #'-'
+    strb    w6, [x2]
+    add     w3, w3, 1
+
+.print_number:
+    // — write number (syscall write: x16=4, svc #0x80)
+    mov     x0, 1           // fd = stdout
+    mov     x1, x2          // buf ptr
+    uxtw    x2, w3          // length
+    mov     x16, #4         // macOS write
+    svc     #0x80
+
+    // — write newline (stack slot sp+31)
+    mov     x0, 1
+    mov     w6, #'\n'
+    strb    w6, [sp, #31]
+    add     x1, sp, #31
+    mov     x2, 1
+    mov     x16, #4
+    svc     #0x80
+
+    // — Epilogue
+    ldp     x29, x30, [sp], #32
+    ret

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -108,6 +108,7 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
         if ch.is_alphabetic() || ch == '_' {
             let ident = consume_until(&mut chars, is_identifier_char);
             match ident.as_str() {
+                "bingus" => tokens.push(Token::KeywordBingus),
                 "int" => tokens.push(Token::KeywordInt),
                 "return" => tokens.push(Token::KeywordReturn),
                 _ => tokens.push(Token::Identifier(ident)),

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -63,4 +63,6 @@ pub enum Token {
     MinusMinus, // --
 
     Equal,
+
+    KeywordBingus,
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -264,6 +264,14 @@ pub fn parse_statements(tokens: &[Token], pos: &mut usize) -> Result<Vec<Stmt>, 
             let decls = parse_declaration_list(tokens, pos)?;
             Ok(decls)
         }
+        Some(Token::KeywordBingus) => {
+            *pos += 1;
+            expect(tokens, pos, &Token::LParen)?;
+            let expr = parse_expr(tokens, pos)?;
+            expect(tokens, pos, &Token::RParen)?;
+            expect(tokens, pos, &Token::Semicolon)?;
+            Ok(vec![Stmt::Bingus(expr)])
+        }
         _ => {
             let expr = parse_expr(tokens, pos)?;
             expect(tokens, pos, &Token::Semicolon)?;


### PR DESCRIPTION
Adds `bingus(arg)`, a built-in pseudo-function, which evaluates expression and prints it into stdout. Available on macOS platform. It uses

Until functions are supported, it would be the only way to print something (e.g. for debug purposes)

Example:
```c
int main() {
    int a = 10, b = 8;
    bingus(a);
    bingus(a * b);
    bingus(b - 10);
}
```
Output:
```
10
80
-2
```

Under the hood compiler adds `bingus_arm64_macos.s` and jumps to `bingus` to print value from `w0` register whenever needed.