### PR TITLE
feat(part 6): add conditional statements and expressions support 

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import os
 import difflib
 
-STAGES = [1, 2, 3, 4, 5]
+STAGES = [1, 2, 3, 4, 5, 6]
 TARGET_ARCHS = ['aarch64']
 BASE = Path("testsuite")
 
@@ -167,14 +167,14 @@ def main():
             valid = stage_dir / "valid"
             invalid = stage_dir / "invalid"
 
-            for f in valid.glob("*.c"):
+            for f in valid.glob("**/*.c"):
                 total += 1
                 if run_test(f, expect_success=True, arch=arch):
                     passed += 1
                 else:
                     failed += 1
 
-            for f in invalid.glob("*.c"):
+            for f in invalid.glob("**/*.c"):
                 total += 1
                 if run_test(f, expect_success=False, arch=arch):
                     passed += 1

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOp, Expr, Function, Program, Stmt, UnaryOp};
+use crate::ast::{BinaryOp, Expr, Function, Program, Statement, UnaryOp};
 use std::fmt;
 
 impl fmt::Display for Expr {
@@ -9,6 +9,9 @@ impl fmt::Display for Expr {
             Expr::BinOp(op, lhs, rhs) => write!(f, "({} {} {})", lhs, op, rhs),
             Expr::Var(name) => write!(f, "(var {})", name),
             Expr::Assign(name, exp) => write!(f, "{} = {}", name, exp),
+            Expr::Conditional(cond, then, els) => {
+                write!(f, "({} ? {} : {})", cond, then, els)
+            }
         }
     }
 }
@@ -56,15 +59,13 @@ impl fmt::Display for BinaryOp {
     }
 }
 
-impl fmt::Display for Stmt {
+impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Stmt::Return(expr) => writeln!(f, "return {}", expr),
-            Stmt::Declare(name, Some(expr)) => writeln!(f, "declare {} = {}", name, expr),
-            Stmt::Declare(name, None) => writeln!(f, "declare {}", name),
-            Stmt::Expr(expr) => writeln!(f, "{}", expr),
-            Stmt::Bingus(expr) => writeln!(f, "bingus {}", expr),
-            Stmt::If(cond, then, else_) => {
+            Statement::Return(expr) => writeln!(f, "return {}", expr),
+            Statement::Expr(expr) => writeln!(f, "{}", expr),
+            Statement::Bingus(expr) => writeln!(f, "bingus {}", expr),
+            Statement::If(cond, then, else_) => {
                 if let Some(else_expr) = else_ {
                     writeln!(f, "if {} {} {}", cond, then, else_expr)
                 } else {
@@ -79,7 +80,7 @@ impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "function int {}:", self.name)?;
         writeln!(f, "    params: ()")?;
-        writeln!(f, "    body:\n        {:?}", self.body)
+        writeln!(f, "    body:\n        {:?}", self.block_items)
     }
 }
 

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -64,6 +64,13 @@ impl fmt::Display for Stmt {
             Stmt::Declare(name, None) => writeln!(f, "declare {}", name),
             Stmt::Expr(expr) => writeln!(f, "{}", expr),
             Stmt::Bingus(expr) => writeln!(f, "bingus {}", expr),
+            Stmt::If(cond, then, else_) => {
+                if let Some(else_expr) = else_ {
+                    writeln!(f, "if {} {} {}", cond, then, else_expr)
+                } else {
+                    writeln!(f, "if {} {}", cond, then)
+                }
+            }
         }
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -39,22 +39,33 @@ pub enum Expr {
     BinOp(BinaryOp, Box<Expr>, Box<Expr>),
     Var(String),
     Assign(String, Box<Expr>),
+    Conditional(Box<Expr>, Box<Expr>, Box<Expr>), // the three expressions are the condition, 'if' expression and 'else' expression, respectively
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Stmt {
+pub enum Statement {
     Return(Expr),
-    Declare(String, Option<Expr>),
     Expr(Expr),
-    If(Expr, Box<Stmt>, Option<Box<Stmt>>), // condition, if branch, else branch (optional)
+    If(Expr, Box<Statement>, Option<Box<Statement>>), // condition, if branch, else branch (optional)
 
     Bingus(Expr), // print expr int val
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum Declaration {
+    Declare(String, Option<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BlockItem {
+    Stmt(Statement),
+    Decl(Declaration),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub name: String,
-    pub body: Vec<Stmt>,
+    pub block_items: Vec<BlockItem>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -46,6 +46,7 @@ pub enum Stmt {
     Return(Expr),
     Declare(String, Option<Expr>),
     Expr(Expr),
+    If(Expr, Box<Stmt>, Option<Box<Stmt>>), // condition, if branch, else branch (optional)
 
     Bingus(Expr), // print expr int val
 }

--- a/src/generator/arm64.rs
+++ b/src/generator/arm64.rs
@@ -195,6 +195,7 @@ fn generate_stmt(g: &mut Generator, stmt: &Stmt) -> Result<(), Box<dyn Error>> {
             writeln!(g.output, "bl\tbingus")?;
             Ok(())
         }
+        _ => Err(format!("unsupported assignment {:?}", stmt).into()),
     }
 }
 

--- a/src/generator/arm64.rs
+++ b/src/generator/arm64.rs
@@ -1,5 +1,7 @@
-use crate::ast::Expr::{Assign, BinOp};
-use crate::ast::{BinaryOp, Expr, Program, Stmt, UnaryOp};
+use crate::ast::BlockItem::{Decl, Stmt};
+use crate::ast::Declaration::Declare;
+use crate::ast::Expr::{Assign, BinOp, Conditional};
+use crate::ast::{BinaryOp, BlockItem, Expr, Program, Statement, UnaryOp};
 use crate::generator::allocator::{Allocator, Variable};
 use crate::generator::label::LabelGenerator;
 use std::error::Error;
@@ -36,6 +38,7 @@ struct Generator<'a> {
     allocator: &'a mut Allocator,
     epilogue: String,
 }
+
 fn generate_expr(g: &mut Generator, expr: &Expr) -> Result<(), Box<dyn Error>> {
     match expr {
         Expr::Const(n) => {
@@ -165,19 +168,67 @@ fn generate_expr(g: &mut Generator, expr: &Expr) -> Result<(), Box<dyn Error>> {
             generate_expr(g, expr)?;
             var.emit_store_from_w0(g.output)?
         } // op => panic!("op {op} is not supported"),
+
+        Conditional(cond, then, els) => {
+            let else_label = g.labels.next("_else");
+            let post_conditional = g.labels.next("_post_conditional");
+
+            generate_expr(g, cond)?; // evaluate cond (e1)
+            writeln!(g.output, "cmp\tw0, #0")?; // compare e1 cond zero
+            writeln!(g.output, "beq\t{}", else_label)?; // if e1 == 0 (false), jump to else (e3)
+
+            generate_expr(g, then)?; // evaluate e2
+            writeln!(g.output, "b\t{}", post_conditional)?; // skip e3
+
+            writeln!(g.output, "{}:", else_label)?;
+            generate_expr(g, els)?; // evaluate else (e3)
+
+            writeln!(g.output, "{}:", post_conditional)?;
+        }
     }
 
     Ok(())
 }
 
-fn generate_stmt(g: &mut Generator, stmt: &Stmt) -> Result<(), Box<dyn Error>> {
+fn generate_stmt(g: &mut Generator, stmt: &Statement) -> Result<(), Box<dyn Error>> {
     match stmt {
-        Stmt::Expr(e) => generate_expr(g, e),
-        Stmt::Return(r) => {
+        Statement::Expr(e) => generate_expr(g, e),
+        Statement::Return(r) => {
             generate_expr(g, r)?;
             writeln!(g.output, "b\t{}", g.epilogue).map_err(Into::into)
         }
-        Stmt::Declare(name, expr) => {
+        Statement::Bingus(expr) => {
+            generate_expr(g, expr)?;
+            writeln!(g.output, "bl\tbingus")?;
+            Ok(())
+        }
+        Statement::If(cond, then, els) => {
+            let else_label = g.labels.next("_else");
+            let post_conditional = g.labels.next("_post_conditional");
+
+            generate_expr(g, cond)?; // evaluate cond (e1)
+            writeln!(g.output, "cmp\tw0, #0")?; // compare e1 cond zero
+            writeln!(g.output, "beq\t{}", else_label)?; // if e1 == 0 (false), jump to else (e3)
+
+            generate_stmt(g, then)?; // evaluate e2
+            writeln!(g.output, "b\t{}", post_conditional)?; // skip e3
+
+            writeln!(g.output, "{}:", else_label)?;
+            if let Some(els) = els {
+                generate_stmt(g, els)?; // evaluate else (e3)
+            }
+            // if els is None, it would just go to post_conditional
+
+            writeln!(g.output, "{}:", post_conditional)?;
+            Ok(())
+        }
+    }
+}
+
+fn generate_block_item(g: &mut Generator, block_item: &BlockItem) -> Result<(), Box<dyn Error>> {
+    match block_item {
+        Stmt(stmt) => generate_stmt(g, stmt),
+        Decl(Declare(name, expr)) => {
             if g.allocator.get(name).is_some() {
                 return Err(format!("variable {} is already declared", name).into());
             }
@@ -190,12 +241,6 @@ fn generate_stmt(g: &mut Generator, stmt: &Stmt) -> Result<(), Box<dyn Error>> {
             }
             Ok(())
         }
-        Stmt::Bingus(expr) => {
-            generate_expr(g, expr)?;
-            writeln!(g.output, "bl\tbingus")?;
-            Ok(())
-        }
-        _ => Err(format!("unsupported assignment {:?}", stmt).into()),
     }
 }
 
@@ -217,11 +262,11 @@ pub fn generate(program: &Program, platform: &str) -> Result<String, Box<dyn std
 
     let mut bingus_used = false;
 
-    for stmt in &function.body {
-        if let Stmt::Bingus(_) = stmt {
+    for stmt in &function.block_items {
+        if let Stmt(Statement::Bingus(_)) = stmt {
             bingus_used = true;
         }
-        if let Stmt::Declare(name, _) = stmt {
+        if let Decl(Declare(name, _)) = stmt {
             dry_allocator.allocate(name.clone(), 4);
         }
     }
@@ -260,11 +305,11 @@ pub fn generate(program: &Program, platform: &str) -> Result<String, Box<dyn std
     };
 
     let mut saw_return = false;
-    for stmt in &function.body {
-        if matches!(stmt, Stmt::Return(_)) {
+    for block_item in &function.block_items {
+        if matches!(block_item, Stmt(Statement::Return(_))) {
             saw_return = true;
         }
-        generate_stmt(&mut generator, stmt)?;
+        generate_block_item(&mut generator, block_item)?;
     }
 
     // emit default return if none provided

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -111,6 +111,8 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
                 "bingus" => tokens.push(Token::KeywordBingus),
                 "int" => tokens.push(Token::KeywordInt),
                 "return" => tokens.push(Token::KeywordReturn),
+                "if" => tokens.push(Token::KeywordIf),
+                "else" => tokens.push(Token::KeywordElse),
                 _ => tokens.push(Token::Identifier(ident)),
             }
             continue;
@@ -173,6 +175,8 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
                 ("&", Token::And),
                 ("|", Token::Or),
                 ("^", Token::Or),
+                ("?", Token::QuestionMark),
+                (":", Token::Colon),
             ],
         ) {
             tokens.push(token);

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -3,6 +3,9 @@ pub enum Token {
     // Keywords
     KeywordInt,    // "int"
     KeywordReturn, // "return"
+    KeywordBingus, // "bingus"
+    KeywordIf,     // "if"
+    KeywordElse,   // "else"
 
     // Identifiers and literals
     Identifier(String), // e.g. "main"
@@ -62,7 +65,8 @@ pub enum Token {
     PlusPlus,   // ++
     MinusMinus, // --
 
-    Equal,
+    Equal, // =
 
-    KeywordBingus,
+    Colon,        // :
+    QuestionMark, // ?
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1,6 +1,6 @@
 use crate::ast::{Function, Program};
 use crate::lexer::Token;
-use crate::parser::expr::parse_statements;
+use crate::parser::expr::parse_block_items;
 
 pub fn expect(tokens: &[Token], pos: &mut usize, expected: &Token) -> Result<(), String> {
     if tokens.get(*pos) == Some(expected) {
@@ -42,13 +42,16 @@ pub fn parse(tokens: &[Token]) -> Result<Program, String> {
     let mut body = Vec::new();
 
     while tokens.get(pos) != Some(&Token::RBrace) {
-        let statements = parse_statements(tokens, &mut pos)?;
+        let statements = parse_block_items(tokens, &mut pos)?;
         body.extend(statements);
     }
 
     expect(tokens, &mut pos, &Token::RBrace)?;
 
     Ok(Program {
-        function: Function { name, body },
+        function: Function {
+            name,
+            block_items: body,
+        },
     })
 }


### PR DESCRIPTION
Follows https://norasandler.com/2018/02/25/Write-a-Compiler-6.html

**Lexer**: support for `if`, `else`, `?`, `:`
**AST**:
- Add `Expr::Conditional`
- Move `Stmt::Declaration` to a separate type `Declaration`
- Introduce `BlockItem = Stmt | Decl`
- Update `Function` to use `Vec<BlockItem>` for `block_items`

**Parser**:
- Add `parse_block_items` and `parse_conditional_expr`
- Update expression precedence to support ternary conditionals
- Support `if`, `else`, and blocks

**Backend**:
- Emit AArch64 code for conditional expressions (`?:`) and `if` statements
- Handle `BlockItem`s and updated function structure
