### PR TITLE
feat: compound statements

### DIFF
--- a/examples/bingus/scope.c
+++ b/examples/bingus/scope.c
@@ -1,0 +1,51 @@
+int main() {
+    int a = 2;
+    int b = 3;
+    {
+        int a = 1;
+        bingus(a);
+        {
+            int b = 14;
+            bingus(a + b);
+        }
+        b = b + a;
+    }
+
+    {
+
+            int a0 = 0;
+            int a1 = 1;
+            int a2 = 2;
+            int a3 = 3;
+            int a4 = 4;
+            int a5 = 5;
+            int a6 = 6;
+            int a7 = 7;
+            int a8 = 8;
+            int a9 = 9;
+            int a10 = 10;
+            int a11 = 11;
+            int a12 = 12;
+            int a13 = 13;
+            int a14 = 14;
+            int a15 = 15;
+            int w = 15;
+
+            bingus(a0 + a15);
+            bingus(a3 + a4);
+            bingus(a7 + a8);
+
+            bingus(112);
+    }
+
+    bingus(228);
+
+    if (b > 0) {
+        int c = 14;
+        c = 2;
+        bingus(c);
+        return c+12;
+    }
+
+    return b;
+}

--- a/examples/bingus/shadow.c
+++ b/examples/bingus/shadow.c
@@ -1,0 +1,9 @@
+int main() {
+    int a = 2;
+    int b = 3;
+    {
+        int a = 4;
+        bingus(a);
+    }
+    return a;
+}

--- a/examples/shadow_scope.c
+++ b/examples/shadow_scope.c
@@ -1,0 +1,42 @@
+int main() {
+    int a = 2;
+    int b = 3;
+    {
+        int a = 1;
+
+        {
+            int b = 14;
+            b += b;
+        }
+        b = b + a;
+    }
+
+    {
+
+            int a0 = 0;
+            int a1 = 1;
+            int a2 = 2;
+            int a3 = 3;
+            int a4 = 4;
+            int a5 = 5;
+            int a6 = 6;
+            int a7 = 7;
+            int a8 = 8;
+            int a9 = 9;
+            int a10 = 10;
+            int a11 = 11;
+            int a12 = 12;
+            int a13 = 13;
+            int a14 = 14;
+            int a15 = 15;
+            int w = 15;
+    }
+
+    if (b > 0) {
+        int c = 14;
+        c = 2;
+        return c+12;
+    }
+
+    return b;
+}

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Built by following [Nora Sandler’s "Write a Compiler"](https://norasandler.com
   - Increment/Decrement(`++`/`--`)
   - Comma operators (`int a = 2, b, c = a + 4;`)
 - [x] Part 6: Conditionals
-- [ ] Part 7: Compound Statements
+- [x] Part 7: Compound Statements
 - [ ] Part 8: Loops
 - [ ] Part 9: Functions
 - [ ] Part 10: Global Variables

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import os
 import difflib
 
-STAGES = [1, 2, 3, 4, 5, 6]
+STAGES = [1, 2, 3, 4, 5, 6, 7]
 TARGET_ARCHS = ['aarch64']
 BASE = Path("testsuite")
 

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -1,4 +1,5 @@
-use crate::ast::{BinaryOp, Expr, Function, Program, Statement, UnaryOp};
+use crate::ast::Declaration::Declare;
+use crate::ast::{BinaryOp, BlockItem, Declaration, Expr, Function, Program, Statement, UnaryOp};
 use std::fmt;
 
 impl fmt::Display for Expr {
@@ -72,6 +73,36 @@ impl fmt::Display for Statement {
                     writeln!(f, "if {} {}", cond, then)
                 }
             }
+            Statement::Compound(block_items) => {
+                writeln!(f, "{{")?;
+                for block_item in block_items {
+                    writeln!(f, "  {}", block_item)?;
+                }
+                writeln!(f, "}}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for Declaration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Declare(name, expr) => {
+                if let Some(expr) = expr {
+                    writeln!(f, "declare {} = {}", name, expr)
+                } else {
+                    writeln!(f, "declare {}", name)
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for BlockItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockItem::Stmt(stmt) => writeln!(f, "stmt {}", stmt),
+            BlockItem::Decl(decl) => writeln!(f, "decl {}", decl),
         }
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -47,6 +47,7 @@ pub enum Statement {
     Return(Expr),
     Expr(Expr),
     If(Expr, Box<Statement>, Option<Box<Statement>>), // condition, if branch, else branch (optional)
+    Compound(Vec<BlockItem>),                         // added
 
     Bingus(Expr), // print expr int val
 }

--- a/src/generator/allocator.rs
+++ b/src/generator/allocator.rs
@@ -6,6 +6,7 @@ pub enum Variable {
     Register(String),
 }
 
+#[derive(Clone)]
 pub struct Allocator {
     next_stack_offset: i32,
     used_registers: Vec<String>,

--- a/src/generator/bingus.rs
+++ b/src/generator/bingus.rs
@@ -1,0 +1,10 @@
+use crate::ast::BlockItem::Stmt;
+use crate::ast::{BlockItem, Statement};
+
+pub fn is_bingus_used(block_item: &BlockItem) -> bool {
+    match block_item {
+        Stmt(Statement::Bingus(_)) => true,
+        Stmt(Statement::Compound(block_items)) => block_items.iter().any(is_bingus_used),
+        _ => false,
+    }
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,3 +1,5 @@
 mod allocator;
 pub mod arm64;
+mod bingus;
 mod label;
+mod stack;

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -1,0 +1,32 @@
+use crate::ast::Declaration::Declare;
+use crate::ast::{BlockItem, Statement};
+use crate::generator::allocator::Allocator;
+
+pub fn simulate_stack_usage(items: &[BlockItem], allocator: &mut Allocator, max: &mut i32) {
+    let old_allocator = allocator.clone();
+
+    for item in items {
+        match item {
+            BlockItem::Decl(Declare(name, _)) => {
+                allocator.allocate(name.clone(), 4);
+                *max = (*max).max(allocator.total_stack_size());
+            }
+            BlockItem::Stmt(stmt) => simulate_stmt_stack(stmt, allocator, max),
+        }
+    }
+
+    *allocator = old_allocator;
+}
+
+fn simulate_stmt_stack(stmt: &Statement, allocator: &mut Allocator, max: &mut i32) {
+    match stmt {
+        Statement::If(_, then, else_) => {
+            simulate_stmt_stack(then, allocator, max);
+            if let Some(els) = else_ {
+                simulate_stmt_stack(els, allocator, max);
+            }
+        }
+        Statement::Compound(items) => simulate_stack_usage(items, allocator, max),
+        _ => {}
+    }
+}

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -311,6 +311,18 @@ pub fn parse_statement(tokens: &[Token], pos: &mut usize) -> Result<Statement, S
 
             Ok(Statement::If(condition, if_branch, else_branch))
         }
+        Some(Token::LBrace) => {
+            // begin compound block
+            *pos += 1;
+            let mut block_items = Vec::new();
+            while tokens.get(*pos) != Some(&Token::RBrace) {
+                let mut parsed = parse_block_items(tokens, pos)?;
+                block_items.append(&mut parsed);
+            }
+            expect(tokens, pos, &Token::RBrace)?;
+            Ok(Statement::Compound(block_items))
+        }
+        Some(Token::RBrace) => Err("Unexpected }".into()),
         _ => {
             let expr = parse_expr(tokens, pos)?;
             expect(tokens, pos, &Token::Semicolon)?;

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -48,6 +48,10 @@ pub fn parse(tokens: &[Token]) -> Result<Program, String> {
 
     expect(tokens, &mut pos, &Token::RBrace)?;
 
+    if pos < tokens.len() {
+        return Err(format!("Unexpected token: {:?}", tokens[pos]));
+    }
+
     Ok(Program {
         function: Function {
             name,


### PR DESCRIPTION
Follows https://norasandler.com/2018/03/14/Write-a-Compiler-7.html

**AST**:
- Add `Statement::Compound` for block items

**Parser**:
- Add support for compound blocks
- Return error for unexpected tokens left after parsing

**Backend**:
- Add `simulate_stack_usage` to determine max stack size for function
- Add `ends_with_return` and `is_bingus_used`, which also check `Statement::Compound` blocks
- For each block generation, clone `Allocator` to support scope variables and shadowing 
- Save/restore x19–x28 registers in prologue/epilogue to satisfy AArch64 callee-saved rules; fixes SIGSEGV seen in stage-7.

The most questionable feature so far. Register handling and stack management remain the most uncertain changes and should be revisited during future implementation of function support.

Dynamic-scope model (stack de-allocation) was disabled after some trials and errors. It should be decided whether to keep static model or move to the dynamic one in future.

