### PR TITLE
feat(part 8): loops

### DIFF
--- a/examples/loops.c
+++ b/examples/loops.c
@@ -1,0 +1,43 @@
+int main() {
+    int a = 1, b, d = a + 5;
+    a++;
+    a++;
+    a--;
+    d--;
+
+    // 1. for loop with initializer only
+    for (int a = 2;;) {
+        d += a; // d = d + 2
+        break;
+    }
+
+    // 2. infinite loop with break
+    for (;;) {
+        d += 3; // d = d + 3
+        break;
+    }
+
+    // 3. for loop with init and increment
+    for (d += 4;; d += 1) {
+        d += 1; // d = d + 1 (one-time)
+        break;
+    }
+
+    // 4. standard loop
+    for (int i = 0; i < 2; i++) {
+        d += i; // d = d + 0, then +1
+    }
+
+    // 5. empty-body loop (does nothing visible)
+    for (int j = 0; j < 2; j++)
+        ; // just loops, no effect
+
+    // 6. controlled by external variable
+    int x = 0;
+    for (; x < 2;) {
+        d += x; // d = d + 0, then +1
+        x++;
+    }
+
+    return d;
+}

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Built by following [Nora Sandler’s "Write a Compiler"](https://norasandler.com
   - Comma operators (`int a = 2, b, c = a + 4;`)
 - [x] Part 6: Conditionals
 - [x] Part 7: Compound Statements
-- [ ] Part 8: Loops
+- [x] Part 8: Loops
 - [ ] Part 9: Functions
 - [ ] Part 10: Global Variables
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-STAGES = [1, 2, 3, 4, 5, 6, 7]
+STAGES = [1, 2, 3, 4, 5, 6, 7, 8]
 TARGET_ARCHS = ["aarch64"]
 BASE = Path("testsuite")
 

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -1,4 +1,5 @@
-use crate::ast::{BinaryOp, BlockItem, Expr, Function, Program, Statement, UnaryOp};
+use crate::ast::Declaration::Declare;
+use crate::ast::{BinaryOp, BlockItem, Declaration, Expr, Function, Program, Statement, UnaryOp};
 use std::fmt;
 
 impl fmt::Display for Expr {
@@ -63,7 +64,13 @@ impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Statement::Return(expr) => writeln!(f, "return {}", expr),
-            Statement::Expr(expr) => writeln!(f, "{}", expr),
+            Statement::Expr(expr) => {
+                if let Some(expr) = expr {
+                    writeln!(f, "{}", expr)
+                } else {
+                    writeln!(f, "null expr")
+                }
+            }
             Statement::Bingus(expr) => writeln!(f, "bingus {}", expr),
             Statement::If { cond, then, els } => {
                 if let Some(else_expr) = els {
@@ -79,6 +86,55 @@ impl fmt::Display for Statement {
                 }
                 writeln!(f, "}}")
             }
+
+            Statement::For {
+                init,
+                cond,
+                post,
+                body,
+            } => {
+                writeln!(
+                    f,
+                    "for ({}; {}; {}) {{",
+                    init.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                    cond,
+                    post.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                )?;
+                writeln!(f, "\t{body}")?;
+                writeln!(f, "}}")
+            }
+
+            Statement::ForDecl {
+                decl,
+                cond,
+                post,
+                body,
+            } => {
+                writeln!(
+                    f,
+                    "for ({}; {}; {}) {{",
+                    decl,
+                    cond,
+                    post.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                )?;
+                writeln!(f, "\t{body}")?;
+                writeln!(f, "}}")
+            }
+
+            Statement::While { cond, body } => {
+                writeln!(f, "while ({cond}) {{")?;
+                writeln!(f, "\t{body}")?;
+                writeln!(f, "}}")
+            }
+
+            Statement::Do { body, cond } => {
+                writeln!(f, "do {{")?;
+                writeln!(f, "\t{body}")?;
+                writeln!(f, "}} while ({cond})")
+            }
+
+            Statement::Break => writeln!(f, "break"),
+            Statement::Continue => writeln!(f, "continue"),
         }
     }
 }
@@ -87,8 +143,21 @@ impl fmt::Display for BlockItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BlockItem::Stmt(stmt) => writeln!(f, "stmt {}", stmt),
-            BlockItem::Decl(name, Some(expr)) => writeln!(f, "decl declare {name} = {expr}"),
-            BlockItem::Decl(name, None) => writeln!(f, "decl declare {name}"),
+            BlockItem::Decl(decl) => writeln!(f, "decl {decl}"),
+        }
+    }
+}
+
+impl fmt::Display for Declaration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Declare(name, expr) => {
+                if let Some(expr) = expr {
+                    writeln!(f, "declare {} = {}", name, expr)
+                } else {
+                    writeln!(f, "declare {}", name)
+                }
+            }
         }
     }
 }

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -96,9 +96,9 @@ impl fmt::Display for Statement {
                 writeln!(
                     f,
                     "for ({}; {}; {}) {{",
-                    init.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                    init.as_ref().map_or(String::new(), |e| format!("{}", e)),
                     cond,
-                    post.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                    post.as_ref().map_or(String::new(), |e| format!("{}", e)),
                 )?;
                 writeln!(f, "\t{body}")?;
                 writeln!(f, "}}")
@@ -115,7 +115,7 @@ impl fmt::Display for Statement {
                     "for ({}; {}; {}) {{",
                     decl,
                     cond,
-                    post.as_ref().map_or("".to_string(), |e| format!("{}", e)),
+                    post.as_ref().map_or(String::new(), |e| format!("{}", e)),
                 )?;
                 writeln!(f, "\t{body}")?;
                 writeln!(f, "}}")

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -78,7 +78,7 @@ pub enum Statement {
     /// `return expr;` statement
     Return(Expr),
     /// Arbitrary expression statement
-    Expr(Expr),
+    Expr(Option<Expr>),
     /// "if-then- optional else" block
     If {
         cond: Expr,
@@ -90,6 +90,46 @@ pub enum Statement {
 
     /// Print the value of the [Expr] as an `int`
     Bingus(Expr),
+
+    /// For loop
+    For {
+        init: Option<Expr>,   // initial expression
+        cond: Expr,           // condition
+        post: Option<Expr>,   // post-expression
+        body: Box<Statement>, // body
+    },
+
+    /// For loop with declaration
+    ForDecl {
+        decl: Declaration,    // initial declaration
+        cond: Expr,           // condition
+        post: Option<Expr>,   // post-expression
+        body: Box<Statement>, // body
+    },
+
+    /// While loop
+    While {
+        cond: Expr,           // condition
+        body: Box<Statement>, // body
+    },
+
+    /// Do loop, stmt is executed first
+    Do {
+        body: Box<Statement>, // body
+        cond: Expr,           // condition
+    },
+
+    /// Break loop
+    Break,
+
+    /// Continue loop
+    Continue,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Declaration {
+    /// Variable declaration with optional initial value.
+    Declare(String, Option<Expr>),
 }
 
 /// Item of a [`Statement::Compound`]
@@ -97,8 +137,7 @@ pub enum Statement {
 pub enum BlockItem {
     /// Arbitrary statement
     Stmt(Statement),
-    /// Variable declaration with optional initial value.
-    Decl(String, Option<Expr>),
+    Decl(Declaration),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/generator/bingus.rs
+++ b/src/generator/bingus.rs
@@ -5,10 +5,12 @@ pub fn is_bingus_used(block_item: &BlockItem) -> bool {
     match block_item {
         Stmt(Statement::Bingus(_)) => true,
 
-        Stmt(Statement::For { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
-        Stmt(Statement::ForDecl { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
-        Stmt(Statement::While { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
-        Stmt(Statement::Do { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
+        Stmt(
+            Statement::For { body, .. }
+            | Statement::ForDecl { body, .. }
+            | Statement::While { body, .. }
+            | Statement::Do { body, .. },
+        ) => is_bingus_used(&Stmt(*body.clone())),
 
         Stmt(Statement::Compound(block_items)) => block_items.iter().any(is_bingus_used),
 

--- a/src/generator/bingus.rs
+++ b/src/generator/bingus.rs
@@ -4,7 +4,14 @@ use crate::ast::{BlockItem, Statement};
 pub fn is_bingus_used(block_item: &BlockItem) -> bool {
     match block_item {
         Stmt(Statement::Bingus(_)) => true,
+
+        Stmt(Statement::For { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
+        Stmt(Statement::ForDecl { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
+        Stmt(Statement::While { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
+        Stmt(Statement::Do { body, .. }) => is_bingus_used(&Stmt(*body.clone())),
+
         Stmt(Statement::Compound(block_items)) => block_items.iter().any(is_bingus_used),
+
         _ => false,
     }
 }

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -1,3 +1,4 @@
+use crate::ast::Declaration::Declare;
 use crate::ast::{BlockItem, Statement};
 use crate::generator::allocator::Allocator;
 
@@ -6,7 +7,7 @@ pub fn simulate_stack_usage(items: &[BlockItem], allocator: &mut Allocator, max:
 
     for item in items {
         match item {
-            BlockItem::Decl(name, _) => {
+            BlockItem::Decl(Declare(name, _)) => {
                 allocator.allocate(name.clone(), 4);
                 *max = (*max).max(allocator.total_stack_size());
             }

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -106,6 +106,11 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
                 "return" => tokens.push(Token::KeywordReturn),
                 "if" => tokens.push(Token::KeywordIf),
                 "else" => tokens.push(Token::KeywordElse),
+                "while" => tokens.push(Token::KeywordWhile),
+                "for" => tokens.push(Token::KeywordFor),
+                "do" => tokens.push(Token::KeywordDo),
+                "break" => tokens.push(Token::KeywordBreak),
+                "continue" => tokens.push(Token::KeywordContinue),
                 _ => tokens.push(Token::Identifier(ident)),
             }
             continue;

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -15,6 +15,16 @@ pub enum Token {
     KeywordIf,
     /// Literal "else"
     KeywordElse,
+    /// Literal "while"
+    KeywordWhile,
+    /// Literal "for"
+    KeywordFor,
+    /// Literal "do"
+    KeywordDo,
+    /// Literal "break"
+    KeywordBreak,
+    /// Literal "continue"
+    KeywordContinue,
 
     /// Identifier, such as "main"
     Identifier(String),

--- a/src/lexer/types.rs
+++ b/src/lexer/types.rs
@@ -3,7 +3,7 @@
 /// unless it's not; some unambiguous tokens are explained here anyway.
 ///
 /// [AST]: crate::ast::types
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Token {
     /// Literal "int"
     KeywordInt,
@@ -134,4 +134,55 @@ pub enum Token {
     QuestionMark,
     /// Literal ":" (part of the ternary expression)
     Colon,
+}
+
+impl TryFrom<&str> for Token {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            ">>=" => Token::ShiftRightEqual,
+            "<<=" => Token::ShiftLeftEqual,
+            "++" => Token::PlusPlus,
+            "--" => Token::MinusMinus,
+            "+=" => Token::PlusEqual,
+            "-=" => Token::MinusEqual,
+            "/=" => Token::SlashEqual,
+            "*=" => Token::AsteriskEqual,
+            "==" => Token::EqualEqual,
+            "!=" => Token::BangEqual,
+            ">=" => Token::GreaterEqual,
+            "<=" => Token::LessEqual,
+            "&&" => Token::AndAnd,
+            "||" => Token::OrOr,
+            "%=" => Token::ModuloEqual,
+            "&=" => Token::AndEqual,
+            "^=" => Token::XorEqual,
+            ">>" => Token::ShiftRight,
+            "<<" => Token::ShiftLeft,
+            "|=" => Token::OrEqual,
+            "+" => Token::Plus,
+            "-" => Token::Minus,
+            "*" => Token::Asterisk,
+            "/" => Token::Slash,
+            "=" => Token::Equal,
+            "!" => Token::Bang,
+            "~" => Token::Tilde,
+            ">" => Token::Greater,
+            "<" => Token::Less,
+            "," => Token::Comma,
+            ";" => Token::Semicolon,
+            "(" => Token::LParen,
+            ")" => Token::RParen,
+            "{" => Token::LBrace,
+            "}" => Token::RBrace,
+            "%" => Token::Modulo,
+            "&" => Token::And,
+            "|" => Token::Or,
+            "^" => Token::Xor,
+            "?" => Token::QuestionMark,
+            ":" => Token::Colon,
+            _ => return Err(()),
+        })
+    }
 }


### PR DESCRIPTION
Follows https://norasandler.com/2018/04/10/Write-a-Compiler-8.html

**Lexer**: 
- Add `for`, `while`, `do`, `break` and `continue` keywords
- `Token`: implement `TryFrom` trait for operators matching

**AST**:
- Change `Stmt::Expr(Expr)` to `Stmt::Expr(Option<Expr>)`
- Add `Stmt::{For, ForDec, While, Do, Break, Continue}`
- Move `Stmt::Declaration` to a separate type `Declaration` (again)

**Parser**:
- Add support for `while (..) {}`, `for (..) {}` and `do {} while (..)`  blocks

**Backend**:
- Emit AArch64 code for loops
- Add `Context` to pass labels for `break` and `continue`

More tests/examples should be written to cover all possible loops declarations:
```c
for (int a = 2;;)
for (;;)
for (;;a+=1)
// etc
```



