### PR TITLE
feat(part 9): functions

### DIFF
--- a/examples/c_std_calls.c
+++ b/examples/c_std_calls.c
@@ -1,0 +1,47 @@
+int putchar(int c);
+int sleep(int seconds);
+int srand(int n);
+int rand();
+int abs(int n);
+int isdigit(int c);
+
+int main() {
+  putchar(68);
+  putchar(101);
+  putchar(109);
+  putchar(111);
+  putchar(10);
+
+  int zero_char = 48; // 0
+
+  int i = 5;
+  while (i > 0) {
+    putchar(zero_char + i);
+    putchar(10);
+    sleep(1);
+    i = i - 1;
+  }
+
+  srand(1234);
+  int r = rand();
+  int roll = (r % 6) + 1;
+
+  putchar(zero_char + roll);
+  putchar(10);
+
+  int neg = 0 - roll;
+  int pos = abs(neg);
+
+  putchar(48 + pos);
+  putchar(10);
+
+  int ok = isdigit(zero_char + 7);
+  if (ok) {
+    putchar(89);
+  } else {
+    putchar(78);
+  }
+  putchar(10);
+
+  return roll;
+}

--- a/examples/hello_world.c
+++ b/examples/hello_world.c
@@ -1,0 +1,19 @@
+int putchar(int c);
+
+int main() {
+    putchar(72);
+    putchar(101);
+    putchar(108);
+    putchar(108);
+    putchar(111);
+    putchar(44);
+    putchar(32);
+    putchar(87);
+    putchar(111);
+    putchar(114);
+    putchar(108);
+    putchar(100);
+    putchar(33);
+    putchar(33);
+    putchar(10);
+}

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Built by following [Nora Sandler’s "Write a Compiler"](https://norasandler.com
 - [x] Part 6: Conditionals
 - [x] Part 7: Compound Statements
 - [x] Part 8: Loops
-- [ ] Part 9: Functions
+- [x] Part 9: Functions (with calls to the C standard library!)
 - [ ] Part 10: Global Variables
 
 ---
@@ -67,7 +67,7 @@ echo $?  # prints: 42
 ### `bingus` keyword
 `bingus(arg)` is a built-in pseudo-function, which evaluates expression and prints it into stdout. Available on macOS platform
 
-Until functions are supported, it is the only way to print something (e.g. for debug purposes)
+**DEPRECATED**: calls to the standard library functions are supported
 
 Example:
 ```c

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-STAGES = [1, 2, 3, 4, 5, 6, 7, 8]
+STAGES = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 TARGET_ARCHS = ["aarch64"]
 BASE = Path("testsuite")
 
@@ -109,6 +109,10 @@ def compare_c_and_s_outputs(c_file: Path, s_file: Path, arch: str = "arm64") -> 
         return True
 
     print(f"{RED}MISMATCH DETECTED{RESET}")
+    print("--- C code ---")
+    print(c_file.read_text())
+    print("--- Compiler generated asm ---")
+    print(s_file.read_text())
     if not match_code:
         print(f"Return codes differ: C={code_c}, ASM={code_s}")
     if not match_output:

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -13,6 +13,11 @@ impl fmt::Display for Expr {
             Expr::Conditional { cond, then, els } => {
                 write!(f, "({} ? {} : {})", cond, then, els)
             }
+
+            Expr::FunCall { name, parameters } => {
+                let param_strs: Vec<String> = parameters.iter().map(|p| format!("{}", p)).collect();
+                write!(f, "{}({})", name, param_strs.join(", "))
+            }
         }
     }
 }
@@ -172,6 +177,6 @@ impl fmt::Display for Function {
 
 impl fmt::Display for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.function)
+        write!(f, "{:?}", self.functions)
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -71,6 +71,8 @@ pub enum Expr {
         then: Box<Expr>,
         els: Box<Expr>,
     },
+    /// Function call
+    FunCall { name: String, parameters: Vec<Expr> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -143,10 +145,11 @@ pub enum BlockItem {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub name: String,
-    pub block_items: Vec<BlockItem>,
+    pub params: Vec<String>,
+    pub block_items: Option<Vec<BlockItem>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
-    pub function: Function,
+    pub functions: Vec<Function>,
 }

--- a/src/generator/allocator.rs
+++ b/src/generator/allocator.rs
@@ -10,7 +10,7 @@ pub enum Variable {
 pub struct Allocator {
     next_stack_offset: i32,
     used_registers: Vec<String>,
-    vars: HashMap<String, Variable>,
+    pub vars: HashMap<String, Variable>,
 }
 
 impl Allocator {

--- a/src/generator/function_validation.rs
+++ b/src/generator/function_validation.rs
@@ -1,0 +1,178 @@
+use crate::ast::{BlockItem, Program};
+use std::collections::HashMap;
+
+enum FuncKind {
+    Decl(usize), // parameters
+    Def(usize),  // parameters
+}
+
+/// Validates the semantic correctness of function declarations, definitions, and calls.
+///
+/// This pass checks for the following errors:
+/// - Multiple definitions of the same function.
+/// - Inconsistent parameter counts across declarations and definitions.
+/// - Function calls with the wrong number of arguments.
+/// - Calls to undefined functions.
+///   Should be called after parsing and before code generation.
+pub fn validate_functions_declarations(program: &Program) -> Result<(), String> {
+    let mut function_map: HashMap<String, FuncKind> = HashMap::new();
+
+    for func in &program.functions {
+        let arity = func.params.len();
+
+        match function_map.get(&func.name) {
+            Some(FuncKind::Def(_)) if func.block_items.is_some() => {
+                return Err(format!("function {} defined multiple times", func.name));
+            }
+
+            Some(FuncKind::Decl(existing_arity)) | Some(FuncKind::Def(existing_arity)) => {
+                if *existing_arity != arity {
+                    return Err(format!(
+                        "function {} declared/defined with inconsistent parameter counts ({:?} vs {:?})",
+                        func.name, existing_arity, arity
+                    ));
+                }
+                // if consistent, do nothing
+            }
+
+            None => {
+                let kind = if func.block_items.is_some() {
+                    FuncKind::Def(func.params.len())
+                } else {
+                    FuncKind::Decl(func.params.len())
+                };
+                function_map.insert(func.name.clone(), kind);
+            }
+        }
+    }
+
+    // Second pass: check function calls
+    for func in &program.functions {
+        if let Some(body) = &func.block_items {
+            validate_function_body(body, &function_map)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates the function body to ensure all function calls are semantically correct.
+///
+/// Checks every expression in the given block for:
+/// - Calls to functions that have not been declared or defined.
+/// - Calls with an incorrect number of arguments (arity mismatch).
+///
+/// This function is called once per function that has a body (i.e., not just a declaration).
+fn validate_function_body(
+    block_items: &[BlockItem],
+    function_map: &HashMap<String, FuncKind>,
+) -> Result<(), String> {
+    use crate::ast::{BlockItem, Expr, Statement};
+
+    fn check_expr(expr: &Expr, function_map: &HashMap<String, FuncKind>) -> Result<(), String> {
+        match expr {
+            Expr::FunCall { name, parameters } => {
+                match function_map.get(name) {
+                    Some(FuncKind::Decl(arity)) | Some(FuncKind::Def(arity)) => {
+                        if parameters.len() != *arity {
+                            return Err(format!(
+                                "function call to `{}` has wrong number of arguments: expected {}, got {}",
+                                name,
+                                arity,
+                                parameters.len()
+                            ));
+                        }
+                    }
+                    None => {
+                        return Err(format!("call to undefined function `{}`", name));
+                    }
+                }
+                for arg in parameters {
+                    check_expr(arg, function_map)?; // recurse
+                }
+            }
+
+            Expr::Assign(_, e) => check_expr(e, function_map)?,
+            Expr::UnOp(_, e) => check_expr(e, function_map)?,
+            Expr::BinOp(_, l, r) => {
+                check_expr(l, function_map)?;
+                check_expr(r, function_map)?;
+            }
+            Expr::Conditional { cond, then, els } => {
+                check_expr(cond, function_map)?;
+                check_expr(then, function_map)?;
+                check_expr(els, function_map)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn check_stmt(
+        stmt: &Statement,
+        function_map: &HashMap<String, FuncKind>,
+    ) -> Result<(), String> {
+        match stmt {
+            Statement::Expr(Some(e)) => check_expr(e, function_map),
+            Statement::Expr(None) => Ok(()),
+            Statement::Return(e) => check_expr(e, function_map),
+            Statement::If { cond, then, els } => {
+                check_expr(cond, function_map)?;
+                check_stmt(then, function_map)?;
+                if let Some(els) = els {
+                    check_stmt(els, function_map)?;
+                }
+                Ok(())
+            }
+            Statement::While { cond, body } | Statement::Do { cond, body } => {
+                check_expr(cond, function_map)?;
+                check_stmt(body, function_map)
+            }
+            Statement::For {
+                init,
+                cond,
+                post,
+                body,
+            } => {
+                if let Some(init) = init {
+                    check_expr(init, function_map)?;
+                }
+                check_expr(cond, function_map)?;
+                if let Some(post) = post {
+                    check_expr(post, function_map)?;
+                }
+                check_stmt(body, function_map)
+            }
+            Statement::ForDecl {
+                decl: _,
+                cond,
+                post,
+                body,
+            } => {
+                check_expr(cond, function_map)?;
+                if let Some(post) = post {
+                    check_expr(post, function_map)?;
+                }
+                check_stmt(body, function_map)
+            }
+            Statement::Compound(items) => {
+                for item in items {
+                    match item {
+                        BlockItem::Stmt(s) => check_stmt(s, function_map)?,
+                        BlockItem::Decl(_) => {}
+                    }
+                }
+                Ok(())
+            }
+            Statement::Break | Statement::Continue | Statement::Bingus(_) => Ok(()),
+        }
+    }
+
+    for item in block_items {
+        if let BlockItem::Stmt(stmt) = item {
+            check_stmt(stmt, function_map)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,5 +1,6 @@
 mod allocator;
 pub mod arm64;
 mod bingus;
+pub mod function_validation;
 mod label;
 mod stack;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use crate::generator::function_validation::validate_functions_declarations;
 use crate::lexer::lex;
 use crate::parser::parse;
 use clap::Parser;
@@ -53,6 +54,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.debug {
         println!("program: {}", program);
     }
+
+    validate_functions_declarations(&program)?;
 
     let asm = generate(&program, &args.platform, args.debug)?;
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -75,6 +75,33 @@ fn parse_factor(tokens: &[Token], pos: &mut usize) -> Result<Expr, String> {
 
         Some(Token::Identifier(name)) => {
             *pos += 1;
+
+            if tokens.get(*pos) == Some(&Token::LParen) {
+                // function
+                *pos += 1; // consume '('
+
+                let mut args = Vec::new();
+
+                if tokens.get(*pos) != Some(&Token::RParen) {
+                    loop {
+                        let arg = parse_expr(tokens, pos)?;
+                        args.push(arg);
+
+                        if tokens.get(*pos) == Some(&Token::Comma) {
+                            *pos += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                expect(tokens, pos, &Token::RParen)?;
+                return Ok(Expr::FunCall {
+                    name: name.clone(),
+                    parameters: args,
+                });
+            }
+
             Ok(Var(name.clone()))
         }
 


### PR DESCRIPTION
Follows https://norasandler.com/2018/06/27/Write-a-Compiler-9.html

**AST**:
- `Function`: add `params: Vec<String>`
- `Program`: store list of functions
- `Expr`: add `FunCall`

**Parser**:
- Add support for functions declarations, definitions and calls

**Backend**:
- Implement the AArch64 C calling convention
  - first 8 integer parameters → w0‑w7; extra parameters spilled to the stack
  - automatic 16‑byte stack alignment with padding slot
  - result returned in w0
- Add helpers `emit_fun_call` and `emit_binop`
- Adopt scratch registers `w11` (`lhs`) and `w12` (in `Modulo` for modulo quotient) so argument registers are never overwritten.
- Support forward‑declared functions and mutual recursion.
- Add validation for function declarations, definitions, and calls

**C standard library is now supported**, functions e.g. `putchar` could be called now.
`bingus` still works, can't wait to add strings to support `printf`.